### PR TITLE
Fix ghost flipping issue when traveling too far from birth pos

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -3069,6 +3069,9 @@ void LivingLifePage::hetuwSetNextActionMessage(const char* msg, int x, int y) {
 
 	playerActionTargetX = x;
 	playerActionTargetY = y;
+
+    applyReceiveOffset(&playerActionTargetX, &playerActionTargetY);
+
 	playerActionTargetNotAdjacent = true;
 	nextActionEating = false;
 	nextActionMessageToSend = autoSprintf( "%s", msg );


### PR DESCRIPTION
When a character travels too far from birth position (max x or y is +/- 16384, see https://github.com/olliez-mods/YummyLife/blob/ebcf538977c617bc8fb82b046bb85ffa1c914927/gameSource/LivingLifePage.cpp#L16704), their flip looks wrong on shift/ctrl+WASD actions. E.g. shift+A while facing east (while mouse click action looks fine). This fixes that by accounting for the `mMapGlobalOffset`.