### PR TITLE
Add a chat log: scrollback panel of recent speech

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -21314,6 +21314,12 @@ void LivingLifePage::step() {
                                     delete [] phexSpeech;
                                     }
 
+                                // YummyLife: chat scrollback
+                                YummyLife::ChatLog::add(
+                                    existing->name,
+                                    existing->currentSpeech,
+                                    existing->id == ourID );
+
                                 double curTime = game_getCurrentTime();
                                 
                                 existing->speechFade = 1.0*fadeMultiplier;

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -69,6 +69,7 @@ static const int maxZoomLevel = sizeof(zoomScales)/sizeof(zoomScales[0]) - 1;
 float HetuwMod::zoomScale;
 float HetuwMod::guiScaleRaw;
 float HetuwMod::guiScale;
+float HetuwMod::qolTextScale = 0.7f;
 int HetuwMod::panelOffsetX;
 int HetuwMod::panelOffsetY;
 int HetuwMod::tutMessageOffsetX;
@@ -105,6 +106,7 @@ unsigned char HetuwMod::charKey_ShowPlayersInRange = 'p';
 unsigned char HetuwMod::charKey_ShowDeathMessages = 254;
 unsigned char HetuwMod::charKey_ShowHomeCords = 'g';
 unsigned char HetuwMod::charKey_ShowHostileTiles = 'u';
+unsigned char HetuwMod::charKey_ShowChatLog = 'i';
 unsigned char HetuwMod::charKey_xRay = 'x';
 unsigned char HetuwMod::charKey_Search = 'j';
 unsigned char HetuwMod::charKey_TeachLanguage = 'l';
@@ -878,6 +880,7 @@ void HetuwMod::initSettings() {
 	yumConfig::registerSetting("key_show_deathmessages", charKey_ShowDeathMessages);
 	yumConfig::registerSetting("key_show_homecords", charKey_ShowHomeCords);
 	yumConfig::registerSetting("key_show_hostiletiles", charKey_ShowHostileTiles);
+	yumConfig::registerSetting("key_show_chatlog", charKey_ShowChatLog);
 
 	yumConfig::registerSetting("key_remembercords", charKey_CreateHome, {preComment: "\n"});
 	yumConfig::registerSetting("key_fixcamera", charKey_FixCamera);
@@ -1003,6 +1006,8 @@ void HetuwMod::initSettings() {
 	yumConfig::registerSetting("init_show_deathmessages", bDrawDeathMessages);
 	yumConfig::registerSetting("init_show_homecords", bDrawHomeCords);
 	yumConfig::registerSetting("init_show_hostiletiles", bDrawHostileTiles);
+	yumConfig::registerSetting("log_chat", YummyLife::ChatLog::bLogToFile, {postComment: " // write speech to " hetuwLogFileName});
+	yumConfig::registerScaledSetting("qol_text_scale", qolTextScale, 10, {postComment: " // text size of the chat log overlay, 10 = full size, default 7"});
 
 	yumConfig::registerSetting("keep_button_pressed_to_fixcamera", bHoldDownTo_FixCamera, {preComment: "\n"});
 	yumConfig::registerSetting("keep_button_pressed_to_findyum", bHoldDownTo_FindYum);
@@ -1161,6 +1166,8 @@ static void shuffle(vector<T> &vec) {
 
 void HetuwMod::initOnBirth() { // will be called from LivingLifePage.cpp
 	ourLiveObject = livingLifePage->getOurLiveObject();
+
+	YummyLife::ChatLog::newLife();
 
 	GPS::onBirth(livingLifePage); 
 	if(livingLifePage->getTutorialNumber() > 0 || !connectedToMainServer) {
@@ -1569,6 +1576,11 @@ void HetuwMod::stepHttpRequests() {
 
 void HetuwMod::onScroll(int dir) {
 	if (Phex::onScroll(dir)) return;
+
+	if (YummyLife::ChatLog::bShow) {
+		YummyLife::ChatLog::scroll(dir);
+		return;
+	}
 
 	if (dir == -1)
 		zoomIncrease();
@@ -3680,6 +3692,11 @@ bool HetuwMod::livingLifeKeyDown(unsigned char inASCII) {
 		if (iDrawNames >= 3) iDrawNames = 0;
 		return true;
 	}
+	if (!commandKey && isCharKey(inASCII, charKey_ShowChatLog)) {
+		YummyLife::ChatLog::bShow = !YummyLife::ChatLog::bShow;
+		if (YummyLife::ChatLog::bShow) YummyLife::ChatLog::resetScroll();
+		return true;
+	}
 	if (!commandKey && !shiftKey && isCharKey(inASCII, charKey_ShowCords)) {
 		bDrawCords = !bDrawCords;
 		return true;
@@ -5317,6 +5334,20 @@ string HetuwMod::getArcTimeStr() {
 	}
 }
 
+doublePair HetuwMod::drawLeftTextWithBckgr(doublePair pos, const char* text, float r, float g, float b) {
+	float textWidth = customFont->measureString(text);
+	float lineHeight = customFont->getFontHeight() * 1.1;
+	float spaceWidth = customFont->hetuwGetSpaceWidth();
+	doublePair recPos = pos;
+	recPos.x += textWidth/2;
+	setDrawColor( 0, 0, 0, 0.75 );
+	drawRect( recPos, (textWidth/2) + spaceWidth*2, lineHeight/2 );
+	setDrawColor( r, g, b, 1 );
+	customFont->drawString( text, pos, alignLeft );
+	pos.y -= lineHeight;
+	return pos;
+}
+
 void HetuwMod::setHelpColorNormal() {
 	setDrawColor( 1.0f, 1.0f, 1.0f, 1 );
 }
@@ -5393,6 +5424,12 @@ void HetuwMod::drawHelp() {
 	if (iDrawNames > 0) setHelpColorSpecial();
 	else setHelpColorNormal();
 	snprintf(str, sizeof(str), "%c TOGGLE SHOW NAMES", toupper(charKey_ShowNames));
+	livingLifePage->hetuwDrawScaledHandwritingFont( str, drawPos, guiScale );
+	drawPos.y -= lineHeight;
+
+	if (YummyLife::ChatLog::bShow) setHelpColorSpecial();
+	else setHelpColorNormal();
+	snprintf(str, sizeof(str), "%c TOGGLE CHAT LOG", toupper(charKey_ShowChatLog));
 	livingLifePage->hetuwDrawScaledHandwritingFont( str, drawPos, guiScale );
 	drawPos.y -= lineHeight;
 

--- a/gameSource/hetuwmod.h
+++ b/gameSource/hetuwmod.h
@@ -292,6 +292,7 @@ public:
 	static unsigned char charKey_ShowDeathMessages;
 	static unsigned char charKey_ShowHomeCords;
 	static unsigned char charKey_ShowHostileTiles;
+	static unsigned char charKey_ShowChatLog;
 	static unsigned char charKey_xRay;
 	static unsigned char charKey_Search;
 	static unsigned char charKey_TeachLanguage;
@@ -418,6 +419,18 @@ public:
 	static bool bWriteLogs;
 	static void createNewLogFile();
 	static void writeLineToLogs(string name, string str);
+
+	// draws one left-aligned text line over a dark backing strip and
+	// returns the position one line further down
+	static doublePair drawLeftTextWithBckgr(doublePair pos, const char* text, float r, float g, float b);
+
+	// YummyLife: text scale for the newer overlays (chat log)
+	static float qolTextScale;
+	static float getQolTextScale() {
+		if (qolTextScale < 0.3f) return 0.3f;
+		if (qolTextScale > 2.0f) return 2.0f;
+		return qolTextScale;
+	}
 
 	static void init();
 	static void initHelpText();

--- a/gameSource/yummyLife.cpp
+++ b/gameSource/yummyLife.cpp
@@ -1,6 +1,7 @@
 #include "yummyLife.h"
 
 #include <stdio.h>
+#include <ctype.h>
 #include <fstream>
 #include <string>
 using std::string;
@@ -114,12 +115,160 @@ void YummyLife::gameStep() {
 }
 
 // Called every frame during living life
+// ---------------------------------------------------------------------------
+// YummyLife::ChatLog — scrollback of recent nearby speech
+// ---------------------------------------------------------------------------
+
+// visible lines in the panel; shared by draw() and scroll()
+static const int chatLogMaxLines = 16;
+// oldest entries are dropped past this so a long, chatty life cannot grow
+// the log without bound
+static const int chatLogMaxEntries = 500;
+
+std::vector<YummyLife::ChatLog::Entry> YummyLife::ChatLog::entries;
+bool YummyLife::ChatLog::bShow = false;
+bool YummyLife::ChatLog::bLogToFile = true;
+int YummyLife::ChatLog::scrollPos = -1;
+
+bool YummyLife::ChatLog::mentionsUs(const char* speech) {
+    LiveObject *us = HetuwMod::ourLiveObject;
+    if (us == NULL || us->name == NULL || speech == NULL) return false;
+
+    char firstName[64];
+    snprintf(firstName, sizeof(firstName), "%s", us->name);
+    char *space = strchr(firstName, ' ');
+    if (space) *space = '\0';
+    size_t nameLen = strlen(firstName);
+    if (nameLen < 2) return false; // 1-letter names give too many false hits
+
+    const char *pos = speech;
+    while ((pos = strstr(pos, firstName)) != NULL) {
+        bool startOk = (pos == speech) || !isalpha((unsigned char)pos[-1]);
+        bool endOk = !isalpha((unsigned char)pos[nameLen]);
+        if (startOk && endOk) return true;
+        pos += 1;
+    }
+    return false;
+}
+
+void YummyLife::ChatLog::add(const char* speakerName, const char* text, bool isSelf) {
+    if (text == NULL || text[0] == '\0') return;
+
+    Entry e;
+    e.kind = (!isSelf && mentionsUs(text)) ? Entry::MENTION : Entry::SPEECH;
+    if (isSelf) {
+        e.name = "YOU";
+    } else if (speakerName != NULL && speakerName[0] != '\0') {
+        // first name only
+        e.name = speakerName;
+        size_t space = e.name.find(' ');
+        if (space != std::string::npos) e.name = e.name.substr(0, space);
+    } else {
+        e.name = "???";
+    }
+    e.text = text;
+    // own speech may still carry trailing map metadata at this point
+    size_t meta = e.text.find(" *map");
+    if (meta != std::string::npos) e.text = e.text.substr(0, meta);
+    if (e.text.empty()) return;
+    if (bLogToFile) {
+        HetuwMod::writeLineToLogs(isSelf ? "say_self" : "say",
+                e.name + hetuwLogSeperator + e.text);
+    }
+    if (e.text.size() > 48) e.text = e.text.substr(0, 46) + "..";
+
+    entries.push_back(e);
+    if ((int)entries.size() > chatLogMaxEntries) {
+        entries.erase(entries.begin());
+        // keep the same lines visible while scrolled back
+        if (scrollPos > 0) scrollPos--;
+    }
+}
+
+void YummyLife::ChatLog::scroll(int dir) {
+    int size = (int)entries.size();
+    if (size <= chatLogMaxLines) return;    // nothing to scroll
+
+    if (dir > 0) {
+        // wheel up = back in time
+        if (scrollPos < 0) scrollPos = size - chatLogMaxLines;
+        scrollPos--;
+        if (scrollPos < 0) scrollPos = 0;
+    } else {
+        // wheel down = forward in time
+        if (scrollPos < 0) return;          // already at the bottom
+        scrollPos++;
+        if (scrollPos + chatLogMaxLines >= size) scrollPos = -1;   // re-stick
+    }
+}
+
+void YummyLife::ChatLog::resetScroll() {
+    scrollPos = -1;
+}
+
+void YummyLife::ChatLog::draw() {
+    if (!bShow) return;
+
+    HetuwFont *customFont = HetuwMod::customFont;
+    double scale = customFont->hetuwGetScaleFactor();
+    customFont->hetuwSetScaleFactor(scale * HetuwMod::guiScale * HetuwMod::getQolTextScale());
+
+    doublePair drawPos = lastScreenViewCenter;
+    drawPos.x -= HetuwMod::viewWidth/2 - 40*HetuwMod::guiScale;
+    drawPos.y += HetuwMod::viewHeight/2 - 300*HetuwMod::guiScale;
+
+    if (entries.empty()) {
+        drawPos = HetuwMod::drawLeftTextWithBckgr(drawPos, "CHAT LOG", 1, 1, 0.4);
+        HetuwMod::drawLeftTextWithBckgr(drawPos, "(NOTHING SAID YET)", 0.7, 0.7, 0.7);
+    } else {
+        int size = (int)entries.size();
+        // clamp defensively: a stale scrollPos must never index out of range
+        int start = scrollPos;
+        if (start < 0 || start > size - chatLogMaxLines) {
+            start = size > chatLogMaxLines ? size - chatLogMaxLines : 0;
+        }
+        if (start < 0) start = 0;
+        int end = start + chatLogMaxLines;
+        if (end > size) end = size;
+
+        char header[64];
+        snprintf(header, sizeof(header), "CHAT LOG [%d-%d of %d]",
+                start + 1, end, size);
+        drawPos = HetuwMod::drawLeftTextWithBckgr(drawPos, header, 1, 1, 0.4);
+
+        char line[128];
+        for (int i=start; i<end; i++) {
+            const Entry &e = entries[i];
+            if (e.kind == Entry::MENTION) {
+                snprintf(line, sizeof(line), "> %s: %s",
+                        e.name.c_str(), e.text.c_str());
+                drawPos = HetuwMod::drawLeftTextWithBckgr(drawPos, line,
+                        1, 0.9, 0.2);
+            } else {
+                snprintf(line, sizeof(line), "  %s: %s",
+                        e.name.c_str(), e.text.c_str());
+                bool self = e.name == "YOU";
+                drawPos = HetuwMod::drawLeftTextWithBckgr(drawPos, line,
+                        1, self ? 0.9 : 1, self ? 0.4 : 1);
+            }
+        }
+    }
+    customFont->hetuwSetScaleFactor(scale);
+}
+
+void YummyLife::ChatLog::newLife() {
+    entries.clear();
+    scrollPos = -1;
+}
+
+
 void YummyLife::livingLifeStep(){
     AFK::step();
     stepActiveRequest();
 }
 
 void YummyLife::livingLifeDraw(){
+    ChatLog::draw();
     if(AFK::isAFK()){
         HetuwFont *customFont = HetuwMod::customFont;
         double scale = customFont->hetuwGetScaleFactor();

--- a/gameSource/yummyLife.h
+++ b/gameSource/yummyLife.h
@@ -139,6 +139,33 @@ class YummyLife {
                 static bool complete(const char* email, const char* hashedChallenge); // Completes the login process with the challenge response
         };
 
+        // Chat scrollback: history of recent nearby speech, toggled with a
+        // key. Lines that mention our first name are highlighted.
+        class ChatLog {
+            struct Entry {
+                enum Kind { SPEECH, MENTION };
+                Kind kind;
+                std::string name;
+                std::string text;
+            };
+            static std::vector<Entry> entries;
+            static int scrollPos;   // -1 = stuck to bottom; >= 0 = index of top visible line
+            // whole-word match of our first name in (all-caps) speech
+            static bool mentionsUs(const char* speech);
+
+            public:
+                static bool bShow;
+                static bool bLogToFile;
+                static void add(const char* speakerName, const char* text, bool isSelf);
+                // wheel scrolling while the panel is open; dir +1 = up (back
+                // in time), -1 = down
+                static void scroll(int dir);
+                // snap back to the newest lines
+                static void resetScroll();
+                static void draw();     // call from livingLifeDraw when bShow
+                static void newLife();
+        };
+
         static void cleanUp();
         static void takingScreenshot();
 


### PR DESCRIPTION
Adds a chat log: a toggleable panel showing a scrollback of recent nearby speech, so you can catch what was said while you were farming off-screen or away from the conversation.

## What it does

- Press **I** (configurable via `key_show_chatlog`) to toggle the panel; the binding is shown in the H help overlay.
- Shows the last 16 lines, newest at the bottom, with `NAME: TEXT` per line. Your own lines appear as `YOU:` in yellow.
- While the panel is open, the **mouse wheel scrolls back** through history; a header shows the window position (`CHAT LOG [12-27 of 84]`). Reopening the panel snaps back to the newest lines.
- Lines that **mention your first name** (whole-word match, 2+ letters) are highlighted with a `>` marker.
- The log **resets each life** and keeps the **last 500 lines**, so a long, chatty life can't grow it without bound.
- Speech is also appended to the existing yumlog file (`say` / `say_self` entries), gated by a new `log_chat` setting (default on).
- A `qol_text_scale` setting (default 7/10) controls the panel text size.

## Implementation notes

- Purely additive: +232 lines, no existing behavior changed.
- The panel lives in `YummyLife::ChatLog` (yummyLife.h/.cpp); hooks are one `add()` call at the speech-reception site in LivingLifePage.cpp and small keybind/config/scroll/reset hooks in hetuwmod.cpp.
- Long lines are truncated to 48 chars for display; the untruncated text is what gets mention-matched and file-logged.
