### PR TITLE
Add native macOS (Apple Silicon) build support

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,22 @@
+# Build-only check for the macOS client. Produces no release artifacts;
+# it exists so mac support stays verifiably green without anyone needing
+# a Mac on hand.
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  build-mac:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Packages
+        run: brew install cmake sdl12-compat openssl@3
+      - name: Vendored library headers
+        run: |
+          mkdir -p CPP-HTTPLib nlohmann
+          curl -L -o CPP-HTTPLib/httplib.h https://raw.githubusercontent.com/yhirose/cpp-httplib/v0.14.3/httplib.h
+          curl -L -o nlohmann/json.hpp https://github.com/nlohmann/json/releases/download/v3.11.3/json.hpp
+      - name: Build
+        run: |
+          cmake -B build -S .
+          cmake --build build -j 3

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ CMakeCache.txt
 CPP-HTTPLib
 openssl-3.0.15
 nlohmann
+
+# macOS:
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,50 @@ if(WIN32)
     target_compile_options(YummyLife_windows PRIVATE ${CLIENT_COMPILE_OPTIONS})
     target_link_libraries(YummyLife_windows opengl32 glu32 mingw32 SDLmain SDL wsock32 winmm ssl crypto ws2_32 crypt32)
     target_link_options(YummyLife_windows PRIVATE -mwindows -static-libstdc++ -static-libgcc)
+elseif(APPLE)
+    # enable_language(OBJC) needs CMake 3.16; only the mac build requires it
+    if(CMAKE_VERSION VERSION_LESS 3.16)
+        message(FATAL_ERROR "The macOS build requires CMake >= 3.16 (for Objective-C support)")
+    endif()
+
+    # __mac__ activates the existing Mac code paths in minorGems (working
+    # directory handling, <OpenGL/gl.h> headers, <SDL.h> includes).
+    # LINUX must stay undefined here or #ifdef LINUX / #elif __mac__
+    # chains take the wrong branch.
+    add_definitions(-D__mac__ -DBSD -DGL_SILENCE_DEPRECATION -DCPPHTTPLIB_OPENSSL_SUPPORT)
+
+    enable_language(OBJC)
+    add_executable(YummyLife_mac ${CLIENT_SOURCE_FILES} ${MINORGEMS_SOURCE_FILES}
+        minorGems/game/platforms/SDL/mac/MenuBarHelper.m)
+    target_compile_options(YummyLife_mac PRIVATE ${CLIENT_COMPILE_OPTIONS})
+
+    # SDL 1.2 API provided by sdl12-compat (brew install sdl12-compat).
+    # FindSDL resolves it from the Homebrew prefix and adds SDLmain plus
+    # -framework Cocoa itself. Under __mac__ the code includes <SDL.h>
+    # directly, so SDL_INCLUDE_DIR (the .../include/SDL dir) is what the
+    # compile line needs.
+    find_package(SDL REQUIRED)
+    target_include_directories(YummyLife_mac PRIVATE ${SDL_INCLUDE_DIR})
+    target_link_libraries(YummyLife_mac ${SDL_LIBRARY})
+
+    # openssl@3 is keg-only in Homebrew, so it is not in the default
+    # search prefixes; ask brew where it lives (works for both the
+    # /opt/homebrew and /usr/local prefixes). An explicit
+    # -DOPENSSL_ROOT_DIR on the command line still wins.
+    if(NOT DEFINED OPENSSL_ROOT_DIR)
+        execute_process(COMMAND brew --prefix openssl@3
+            OUTPUT_VARIABLE BREW_OPENSSL_PREFIX
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE BREW_OPENSSL_RC
+            ERROR_QUIET)
+        if(BREW_OPENSSL_RC EQUAL 0)
+            set(OPENSSL_ROOT_DIR "${BREW_OPENSSL_PREFIX}")
+        endif()
+    endif()
+    find_package(OpenSSL REQUIRED)
+    target_link_libraries(YummyLife_mac OpenSSL::SSL OpenSSL::Crypto)
+
+    target_link_libraries(YummyLife_mac "-framework OpenGL")
 else()
     add_definitions(-DLINUX -DCPPHTTPLIB_OPENSSL_SUPPORT)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Open a bug report using the Issues tab above.
 
 # Compiling
 
-Compiling on Linux is recommended for release builds, but a native build on Windows is possible for development use.
+Compiling on Linux is recommended for release builds, but a native build on Windows or macOS is possible for development use.
 
 ## Linux
 
@@ -160,6 +160,60 @@ YummyLife_windows.exe will be in that `build/` directory.
 You will need to copy the libwinpthread-1.dll from MSYS (typically at `C:\msys64\mingw32\bin\libwinpthread-1.dll`) to
 your OHOL directory to be able to use a .exe built in this way. Because of this additional dependency introduced by
 MSYS, distributing this .exe is not recommended.
+
+## macOS
+
+The mac build is source-only: it produces a bare `YummyLife_mac` binary linked against
+Homebrew libraries, not a distributable .app bundle.
+
+### Dependencies
+
+Install [Homebrew](https://brew.sh/), then:
+
+```
+brew install cmake sdl12-compat openssl@3
+```
+
+(SDL 1.2 itself is unmaintained and no longer builds on modern macOS;
+[sdl12-compat](https://github.com/libsdl-org/sdl12-compat) provides the same API on top of
+SDL2 and is what Homebrew ships.)
+
+Fetch the two vendored library headers into the repo root (the setup script in
+`yummyLifeBuildScripts/` uses wget, which stock macOS lacks):
+
+```
+mkdir -p CPP-HTTPLib nlohmann
+curl -L -o CPP-HTTPLib/httplib.h https://raw.githubusercontent.com/yhirose/cpp-httplib/v0.14.3/httplib.h
+curl -L -o nlohmann/json.hpp https://github.com/nlohmann/json/releases/download/v3.11.3/json.hpp
+```
+
+### Building for macOS
+
+```
+mkdir build
+cd build
+cmake .. && make -j8
+```
+
+`YummyLife_mac` will be in that `build/` directory.
+
+### Running
+
+Copy `YummyLife_mac` next to the game data folders (the mac OHOL distribution is a folder
+containing `animations/`, `objects/`, `sprites/`, etc. alongside the `OneLife_v###.app`)
+and launch it from Terminal:
+
+```
+cd /path/to/your/OneLife/folder
+./YummyLife_mac
+```
+
+The binary is not double-clickable: it expects the game data in the current working
+directory. If you don't own the Steam/mac version, the same data folders can be obtained
+from [OneLifeData7](https://github.com/jasonrohrer/OneLifeData7) (checkout the latest
+`OneLife_v*` tag), plus the `graphics/`, `otherSounds/`, `languages/`, `settings/`,
+`language.txt`, `us_english_60.txt`, `wordList.txt` and the two `*.aiff` files from this
+repo's `gameSource/`.
 
 # Merging upstream changes
 

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -21283,7 +21283,7 @@ void LivingLifePage::step() {
                             if( firstSpace != NULL ) {
 
                                 // YummyLife: chat scrollback
-                                doublePair player_pos = { existing->xd, existing->yd };
+                                doublePair player_pos = { (double)existing->xd, (double)existing->yd };
                                 time_t timestamp = time(NULL);
                                 YummyLife::ChatLog::add(
                                     existing->name,

--- a/gameSource/hetuwmod.cpp
+++ b/gameSource/hetuwmod.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <fstream>
 #include <string>
+#include <sstream>
 #include <unordered_set>
 
 #include "LivingLifePage.h"

--- a/gameSource/yummyLife.cpp
+++ b/gameSource/yummyLife.cpp
@@ -157,7 +157,7 @@ void YummyLife::ChatLog::refreshDistancesForCurrentPosition() {
     LiveObject *us = HetuwMod::ourLiveObject;
     if (us == NULL) return;
 
-    doublePair currentPos = { us->xd, us->yd };
+    doublePair currentPos = { (double)us->xd, (double)us->yd };
     if (lastDistanceCalcPos.x == currentPos.x &&
         lastDistanceCalcPos.y == currentPos.y) {
         return;

--- a/minorGems/game/platforms/SDL/gameSDL.cpp
+++ b/minorGems/game/platforms/SDL/gameSDL.cpp
@@ -1726,6 +1726,16 @@ int mainFunction( int inNumArgs, char **inArgs ) {
     #endif
         
 
+    #ifdef __mac__
+        // sdl12-compat's OpenGL-scaling FBO can become permanently
+        // incomplete after macOS window-server events (occlusion,
+        // display changes), leaving GL_INVALID_FRAMEBUFFER_OPERATION
+        // on every draw (frozen/black screen).  Render unscaled
+        // instead.  setenv with no overwrite so users can still force
+        // scaling back on from the environment.
+        setenv( "SDL12COMPAT_OPENGL_SCALING", "0", 0 );
+    #endif
+
     // check result below, after opening log, so we can log failure
     Uint32 flags = SDL_INIT_VIDEO | SDL_INIT_NOPARACHUTE;
     if( getUsesSound() ) {

--- a/minorGems/game/platforms/SDL/mac/MenuBarHelper.m
+++ b/minorGems/game/platforms/SDL/mac/MenuBarHelper.m
@@ -1,0 +1,16 @@
+#import <Cocoa/Cocoa.h>
+
+#import "SDLMain_Ext.h"
+
+/* NSMenu_setMenuBarVisible normally comes from SDLMain.m, but when
+   linking against sdl12-compat's libSDLmain.a (which provides main),
+   compiling all of SDLMain.m would duplicate main.  This file supplies
+   just the helper that ScreenGL_SDL.cpp needs for fullscreen mode. */
+
+void NSMenu_setMenuBarVisible(int flag) {
+    if (flag) {
+        [NSMenu setMenuBarVisible:TRUE];
+    } else {
+        [NSMenu setMenuBarVisible:FALSE];
+    }
+}


### PR DESCRIPTION
Adds native macOS (Apple Silicon) support as a **source-only** build target: `cmake --build build` produces a bare `YummyLife_mac` binary. No .app bundle, no signing/notarization, no release artifacts — out of scope here, and none of your release tooling is touched.

I've been playing this port daily for over a week on an M-series Mac (account-key login, full lives on bigserver2, fullscreen, sound, chat, Phex over HTTPS). Voice recording and the Steam login path are untested — upstream's mac stubs for those (`runSteamGateClient`, `relaunchGame`) are unchanged.

## What's in it

**Commit 1 — the port.**
- `CMakeLists.txt`: a new `elseif(APPLE)` branch. Linux and Windows are unaffected — no existing line is modified, Linux still takes the `else()` branch, and the mingw cross-build from a Mac still takes `WIN32` (the toolchain file sets `CMAKE_SYSTEM_NAME=Windows`). SDL comes from `sdl12-compat` (SDL 1.2 itself no longer builds on modern macOS; `find_package(SDL)` resolves the compat lib from Homebrew). Keg-only `openssl@3` is located via `brew --prefix`, so both Intel and Apple Silicon prefixes work, and an explicit `-DOPENSSL_ROOT_DIR` still wins.
- `minorGems/` (I know this is Jason's tree, so the delta is deliberately minimal — two things, both purely additive):
  - `gameSDL.cpp`: one `#ifdef __mac__` block setting `SDL12COMPAT_OPENGL_SCALING=0` before `SDL_Init`. Without it, sdl12-compat's GL-scaling FBO goes permanently incomplete after window-server events (occlusion, display sleep) and the game freezes with `GL_INVALID_FRAMEBUFFER_OPERATION` on every draw. `setenv` uses overwrite=0 so users can force scaling back on from the environment. This env var is a no-op under any other SDL.
  - `mac/MenuBarHelper.m` (new file): supplies `NSMenu_setMenuBarVisible` for fullscreen. Under `__mac__` the app's `main` becomes `SDL_main` and the real entry point comes from sdl12-compat's `libSDLmain.a`, so compiling all of `SDLMain.m` would define `main` twice; this 14-line file is the one helper `ScreenGL_SDL.cpp` needs, copied verbatim from `SDLMain.m` so the two stay trivially diffable. Happy to move it out of `minorGems/` if you'd rather keep that tree byte-clean.
- `hetuwmod.cpp`: one `<sstream>` include — libc++ needs it for the existing `std::stringstream` uses; libstdc++ pulls it in transitively. No effect on gcc builds.
- `README.md`: a `## macOS` section (deps, fetching the two vendored headers with curl since stock macOS has no wget, building, and how to run against an existing mac OHOL data folder).

**Commit 2 — clang narrowing fixes.** Two brace initializers in the new chat-log code build `doublePair` from int `xd`/`yd` fields. GCC accepts that (at most `-Wnarrowing`); clang rejects it outright: `error: non-constant-expression cannot be narrowed from type 'int' to 'double' in initializer list [-Wc++11-narrowing]`. Explicit casts, values are exact in double, zero behavior change — this unbreaks any clang build, not just macOS.

**Commit 3 — CI.** A build-only job on the free `macos-latest` (arm64) runners so mac support stays verifiably green without you needing a Mac. It uses no event inputs, no secrets, and uploads nothing. Two judgement calls left to you: it matches the existing workflow's `actions/checkout@v2` (happy to bump both to v4), and it triggers on `pull_request` + manual dispatch only (add `push: branches: [master]` if you want post-merge coverage too).
